### PR TITLE
Fix: Correct model error in MST_Plus_Plus during real experiment

### DIFF
--- a/real/train_code/architecture/MST_Plus_Plus.py
+++ b/real/train_code/architecture/MST_Plus_Plus.py
@@ -277,27 +277,12 @@ class MST_Plus_Plus(nn.Module):
         self.body = nn.Sequential(*modules_body)
         self.conv_out = nn.Conv2d(n_feat, out_channels, kernel_size=3, padding=(3 - 1) // 2,bias=False)
 
-    def initial_x(self, y):
-        """
-        :param y: [b,1,256,310]
-        :param Phi: [b,28,256,310]
-        :return: z: [b,28,256,310]
-        """
-        nC, step = 28, 2
-        bs, row, col = y.shape
-        x = torch.zeros(bs, nC, row, row).cuda().float()
-        for i in range(nC):
-            x[:, i, :, :] = y[:, :, step * i:step * i + col - (nC - 1) * step]
-        x = self.fution(x)
-        return x
 
     def forward(self, x, input_mask=None):
         """
         x: [b,c,h,w]
         return out:[b,c,h,w]
         """
-        x = self.initial_x(x)
-
         b, c, h_inp, w_inp = x.shape
         hb, wb = 8, 8
         pad_h = (hb - h_inp % hb) % hb


### PR DESCRIPTION
Fixed an issue in the MST_Plus_Plus model that was causing incorrect behavior during the real experiment. The error was due to wrong input.

This fix ensures that the MST_Plus_Plus model now performs as expected in the real experiment, producing accurate results consistent with the designed behavior.
